### PR TITLE
fix: correct typo on apis/migrate, update nix flake

### DIFF
--- a/.github/workflows/wf_build_artifacts.yaml
+++ b/.github/workflows/wf_build_artifacts.yaml
@@ -77,19 +77,6 @@ jobs:
         make build-docker-image ARCH=${{ inputs.GOARCH }}
       if: ${{ ( inputs.GOOS == 'linux' ) }}
 
-    - name: "Ammend manifest"
-      run: |
-          # hack that speeds up build a lot by crosscompiling with nix/go
-          # and avoiding to use qemu
-          mkdir tmp && cd tmp
-          tar xvzf ../result
-          sed -i 's/arm64/amd64/g' *.json
-          tar cvzf image *
-          rm ../result
-          cp image ../result
-      shell: bash
-      if: ${{ ( inputs.GOOS == 'linux' && inputs.GOARCH == 'amd64' ) }}
-
     - name: "Push docker-image to artifact repository"
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/wf_publish.yaml
+++ b/.github/workflows/wf_publish.yaml
@@ -50,12 +50,14 @@ jobs:
           export VERSION=${{ steps.vars.outputs.VERSION }}
           export CONTAINER_NAME=nhost/mcp-nhost
 
-          docker load < ~/artifacts/mcp-nhost-docker-image-$VERSION-linux-amd64/result
-          docker tag mcp-nhost:$VERSION $CONTAINER_NAME:$VERSION-amd64
+          skopeo copy --insecure-policy \
+            dir:/home/runner/artifacts/mcp-nhost-docker-image-$VERSION-linux-amd64 \
+            docker-daemon:$CONTAINER_NAME:$VERSION-amd64
           docker push $CONTAINER_NAME:$VERSION-amd64
 
-          docker load < ~/artifacts/mcp-nhost-docker-image-$VERSION-linux-arm64/result
-          docker tag mcp-nhost:$VERSION $CONTAINER_NAME:$VERSION-arm64
+          skopeo copy --insecure-policy \
+            dir:/home/runner/artifacts/mcp-nhost-docker-image-$VERSION-linux-arm64 \
+            docker-daemon:$CONTAINER_NAME:$VERSION-arm64
           docker push $CONTAINER_NAME:$VERSION-arm64
 
           docker manifest create \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else ifeq ($(shell uname -m),arm64)
   ARCH?=arm64
 else ifeq ($(shell uname -m),aarch64)
   HOST_ARCH?=aarch64
-   ARCH?=aarch64
+  ARCH?=aarch64
 endif
 
 ifeq ($(shell uname -o),Darwin)
@@ -39,6 +39,7 @@ help: ## Show this help.
 .PHONY: get-version
 get-version:  ## Return version
 	@sed -i '/^\s*version = "0\.0\.0-dev";/s//version = "${VERSION}";/' flake.nix
+	@sed -i '/^\s*created = "1970-.*";/s//created = "${shell date --utc '+%Y-%m-%dT%H:%M:%SZ'}";/' flake.nix
 	@echo $(VERSION)
 
 
@@ -90,4 +91,6 @@ build-docker-image:  ## Build docker image
 	nix build $(docker-build-options) \
 		.\#packages.$(HOST_ARCH)-linux.docker-image-$(ARCH) \
 		--print-build-logs
-	docker load < result
+	skopeo copy --insecure-policy \
+		--override-arch $(ARCH) \
+		dir:./result docker-daemon:nhost/mcp-nhost:$(VERSION)

--- a/flake.lock
+++ b/flake.lock
@@ -101,6 +101,10 @@
           "nixops",
           "nix-filter"
         ],
+        "nix2container": [
+          "nixops",
+          "nix2container"
+        ],
         "nixops": "nixops",
         "nixpkgs": [
           "nixops",

--- a/flake.lock
+++ b/flake.lock
@@ -33,18 +33,40 @@
         "type": "github"
       }
     },
+    "nix2container": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749158376,
+        "narHash": "sha256-uirStFNxauh0lxzBowcp28X+Sq7JgsBIDnbwbAfZwf8=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "0f8974c58755dba441df03598eefd1e1cd50e341",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixops": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
+        "nix2container": "nix2container",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745925792,
-        "narHash": "sha256-tSN3G8dAm4cX6vG6Agm/jXGhBrsHgewHCHVF0LR52fQ=",
+        "lastModified": 1750077810,
+        "narHash": "sha256-MsaskaJ+a0O06SZ6eVLfhx+oMcO6R8PFlyBpRwnMn8E=",
         "owner": "nhost",
         "repo": "nixops",
-        "rev": "555a2f79e2a0187c0e2f33d519c8e79041b681e1",
+        "rev": "1ed1112322d418277f25f4a13f6b0f2f5928fa6e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,10 @@
         nativeBuildInputs = [
         ];
 
-        nixops-lib = nixops.lib { inherit pkgs; };
+        nixops-lib = nixops.lib {
+          inherit pkgs;
+          nix2containerPkgs = nixops.inputs.nix2container.packages.${system};
+        };
 
         name = "mcp-nhost";
         version = "0.0.0-dev";
@@ -132,13 +135,13 @@
 
           docker-image-arm64 = nixops-lib.go.docker-image {
             inherit name version buildInputs;
-
+            created = "now";
             package = mcp-nhost-arm64-linux;
           };
 
           docker-image-amd64 = nixops-lib.go.docker-image {
             inherit name version buildInputs;
-
+            created = "now";
             package = mcp-nhost-amd64-linux;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -135,13 +135,13 @@
 
           docker-image-arm64 = nixops-lib.go.docker-image {
             inherit name version buildInputs;
-            created = "now";
+            created = "1970-01-01T00:00:00Z";
             package = mcp-nhost-arm64-linux;
           };
 
           docker-image-amd64 = nixops-lib.go.docker-image {
             inherit name version buildInputs;
-            created = "now";
+            created = "1970-01-01T00:00:00Z";
             package = mcp-nhost-amd64-linux;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
     nixpkgs.follows = "nixops/nixpkgs";
     flake-utils.follows = "nixops/flake-utils";
     nix-filter.follows = "nixops/nix-filter";
+    nix2container.follows = "nixops/nix2container";
   };
 
-  outputs = { self, nixops, nixpkgs, flake-utils, nix-filter }:
+  outputs = { self, nixops, nixpkgs, flake-utils, nix-filter, nix2container }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [
@@ -57,13 +58,12 @@
         nativeBuildInputs = [
         ];
 
-        nixops-lib = nixops.lib {
-          inherit pkgs;
-          nix2containerPkgs = nixops.inputs.nix2container.packages.${system};
-        };
+        nix2containerPkgs = nix2container.packages.${system};
+        nixops-lib = nixops.lib { inherit pkgs nix2containerPkgs; };
 
         name = "mcp-nhost";
         version = "0.0.0-dev";
+        created = "1970-01-01T00:00:00Z";
         submodule = ".";
 
         tags = [ ];
@@ -84,6 +84,7 @@
         devShells = flake-utils.lib.flattenTree {
           default = nixops-lib.go.devShell {
             buildInputs = [
+              pkgs.skopeo
             ] ++ checkDeps ++ buildInputs ++ nativeBuildInputs;
           };
         };
@@ -134,14 +135,16 @@
           });
 
           docker-image-arm64 = nixops-lib.go.docker-image {
-            inherit name version buildInputs;
-            created = "1970-01-01T00:00:00Z";
+            inherit name version created buildInputs;
+            arch = "arm64";
+
             package = mcp-nhost-arm64-linux;
           };
 
           docker-image-amd64 = nixops-lib.go.docker-image {
-            inherit name version buildInputs;
-            created = "1970-01-01T00:00:00Z";
+            inherit name version created buildInputs;
+            arch = "amd64";
+
             package = mcp-nhost-amd64-linux;
           };
 

--- a/nhost/graphql/openapi.yaml
+++ b/nhost/graphql/openapi.yaml
@@ -10,7 +10,7 @@ security:
 paths:
   /v2/query:
     post:
-      summary: Execute database operations. Do not use to modify the database schema, use /v1/migrate instead
+      summary: Execute database operations. Do not use to modify the database schema, use /apis/migrate instead
       description: Execute SQL queries and other database operations
       operationId: executeQuery
       requestBody:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect API path reference in OpenAPI documentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openapi.yaml</strong><dd><code>Fix incorrect API path reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

nhost/graphql/openapi.yaml

<li>Corrected the API path reference from <code>/v1/migrate</code> to <code>/apis/migrate</code> in <br>the summary for the <code>/v2/query</code> endpoint


</details>


  </td>
  <td><a href="https://github.com/nhost/mcp-nhost/pull/26/files#diff-23dfb73f160b8fea17bff0f3298e4c9f444f499351dab9591b6afdaf24e1f16c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>